### PR TITLE
draft05-interopsupport-with-moqrs-watchendpoint

### DIFF
--- a/lib/transport/client.ts
+++ b/lib/transport/client.ts
@@ -47,13 +47,13 @@ export class Client {
 		const setup = new Setup.Stream(reader, writer)
 
 		// Send the setup message.
-		await setup.send.client({ versions: [Setup.Version.DRAFT_04], role: this.config.role })
+		await setup.send.client({ versions: [Setup.Version.DRAFT_05], role: this.config.role })
 
 		// Receive the setup message.
 		// TODO verify the SETUP response.
 		const server = await setup.recv.server()
 
-		if (server.version != Setup.Version.DRAFT_04) {
+		if (server.version != Setup.Version.DRAFT_05) {
 			throw new Error(`unsupported server version: ${server.version}`)
 		}
 

--- a/lib/transport/objects.ts
+++ b/lib/transport/objects.ts
@@ -82,17 +82,17 @@ export class Objects {
 		if (h.type == StreamType.Object) {
 			await w.u53(h.group)
 			await w.u53(h.object)
-			await w.u53(h.priority)
+			await w.u8(h.priority)
 			await w.u53(h.status)
 
 			res = new ObjectWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Group) {
 			await w.u53(h.group)
-			await w.u53(h.priority)
+			await w.u8(h.priority)
 
 			res = new GroupWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Track) {
-			await w.u53(h.priority)
+			await w.u8(h.priority)
 
 			res = new TrackWriter(h, w) as WriterType<T>
 		} else {
@@ -121,7 +121,7 @@ export class Objects {
 				type,
 				sub: await r.u62(),
 				track: await r.u62(),
-				priority: await r.u53(),
+				priority: await r.u8(),
 			}
 
 			res = new TrackReader(h, r)
@@ -131,7 +131,7 @@ export class Objects {
 				sub: await r.u62(),
 				track: await r.u62(),
 				group: await r.u53(),
-				priority: await r.u53(),
+				priority: await r.u8(),
 			}
 			res = new GroupReader(h, r)
 		} else if (type == StreamType.Object) {
@@ -142,7 +142,7 @@ export class Objects {
 				group: await r.u53(),
 				object: await r.u53(),
 				status: await r.u53(),
-				priority: await r.u53(),
+				priority: await r.u8(),
 			}
 
 			res = new ObjectReader(h, r)

--- a/lib/transport/setup.ts
+++ b/lib/transport/setup.ts
@@ -9,6 +9,7 @@ export enum Version {
 	DRAFT_02 = 0xff000002,
 	DRAFT_03 = 0xff000003,
 	DRAFT_04 = 0xff000004,
+	DRAFT_05 = 0xff000005,
 	KIXEL_00 = 0xbad00,
 	KIXEL_01 = 0xbad01,
 }

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -72,6 +72,8 @@ export class Subscriber {
 			trackId: id,
 			namespace,
 			name: track,
+			subscriber_priority: 127, // default to mid value, see: https://github.com/moq-wg/moq-transport/issues/504
+			group_order: Control.GroupOrder.Publisher,
 			location: {
 				mode: "latest_group",
 			},


### PR DESCRIPTION
The PR holds the code changes for interop support of "/watch" in moq-js with draft-05 version [moq-rs](https://github.com/TilsonJoji/englishm-moq-rs).

Further support has to be integrated for /publish in moq-js, to be done in upcoming commits.

