### PR TITLE
draft-05 interop with moq-rs (publish/ publish endpoint)

### DIFF
--- a/lib/contribute/broadcast.ts
+++ b/lib/contribute/broadcast.ts
@@ -192,7 +192,7 @@ export class Broadcast {
 		// Create a new stream for each segment.
 		const stream = await subscriber.group({
 			group: segment.id,
-			priority: 0, // TODO
+			publisher_priority: 127, // TODO, default to mid value, see: https://github.com/moq-wg/moq-transport/issues/504
 		})
 
 		let object = 0

--- a/lib/transport/control.ts
+++ b/lib/transport/control.ts
@@ -76,7 +76,7 @@ export interface Subscribe {
 export enum GroupOrder {
 	Publisher = 0x0,
 	Ascending = 0x1,
-	Descending = 0x2
+	Descending = 0x2,
 }
 
 export type Location = LatestGroup | LatestObject | AbsoluteStart | AbsoluteRange

--- a/lib/transport/objects.ts
+++ b/lib/transport/objects.ts
@@ -18,7 +18,7 @@ export interface TrackHeader {
 	type: StreamType.Track
 	sub: bigint
 	track: bigint
-	priority: number // VarInt with a u32 maximum value
+	publisher_priority: number // VarInt with a u32 maximum value
 }
 
 export interface TrackChunk {
@@ -32,7 +32,7 @@ export interface GroupHeader {
 	sub: bigint
 	track: bigint
 	group: number // The group sequence, as a number because 2^53 is enough.
-	priority: number // VarInt with a u32 maximum value
+	publisher_priority: number // VarInt with a u32 maximum value
 }
 
 export interface GroupChunk {
@@ -46,7 +46,7 @@ export interface ObjectHeader {
 	track: bigint
 	group: number
 	object: number
-	priority: number
+	publisher_priority: number
 	status: number
 }
 
@@ -82,17 +82,17 @@ export class Objects {
 		if (h.type == StreamType.Object) {
 			await w.u53(h.group)
 			await w.u53(h.object)
-			await w.u8(h.priority)
+			await w.u8(h.publisher_priority)
 			await w.u53(h.status)
 
 			res = new ObjectWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Group) {
 			await w.u53(h.group)
-			await w.u8(h.priority)
+			await w.u8(h.publisher_priority)
 
 			res = new GroupWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Track) {
-			await w.u8(h.priority)
+			await w.u8(h.publisher_priority)
 
 			res = new TrackWriter(h, w) as WriterType<T>
 		} else {

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -214,7 +214,7 @@ export class SubscribeRecv {
 			type: StreamType.Track,
 			sub: this.#id,
 			track: this.#trackId,
-			priority: props?.priority ?? 0,
+			publisher_priority: props?.priority ?? 127,
 		})
 	}
 
@@ -225,7 +225,7 @@ export class SubscribeRecv {
 			sub: this.#id,
 			track: this.#trackId,
 			group: props.group,
-			priority: props.priority ?? 0,
+			publisher_priority: props.priority ?? 127,
 		})
 	}
 
@@ -237,7 +237,7 @@ export class SubscribeRecv {
 			track: this.#trackId,
 			group: props.group,
 			object: props.object,
-			priority: props.priority ?? 0,
+			publisher_priority: props.priority ?? 127,
 			status: 0,
 		})
 	}

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -86,7 +86,12 @@ export class Publisher {
 		this.#subscribe.set(msg.id, subscribe)
 		await this.#subscribeQueue.push(subscribe)
 
-		await this.#control.send({ kind: Control.Msg.SubscribeOk, id: msg.id, expires: 0n, group_order: msg.group_order })
+		await this.#control.send({
+			kind: Control.Msg.SubscribeOk,
+			id: msg.id,
+			expires: 0n,
+			group_order: msg.group_order,
+		})
 	}
 
 	recvUnsubscribe(_msg: Control.Unsubscribe) {
@@ -182,7 +187,12 @@ export class SubscribeRecv {
 		this.#state = "ack"
 
 		// Send the control message.
-		return this.#control.send({ kind: Control.Msg.SubscribeOk, id: this.#id, expires: 0n, group_order: this.groupOrder })
+		return this.#control.send({
+			kind: Control.Msg.SubscribeOk,
+			id: this.#id,
+			expires: 0n,
+			group_order: this.groupOrder,
+		})
 	}
 
 	// Close the subscription with an error.


### PR DESCRIPTION
The PR holds the code changes for interop support of "/publish" in moq-js with draft-05 version [moq-rs](https://github.com/TilsonJoji/englishm-moq-rs).

