### PR TITLE
draft-05 interop with moq-rs (publish endpoint)

### DIFF
--- a/lib/contribute/broadcast.ts
+++ b/lib/contribute/broadcast.ts
@@ -192,7 +192,7 @@ export class Broadcast {
 		// Create a new stream for each segment.
 		const stream = await subscriber.group({
 			group: segment.id,
-			priority: 0, // TODO
+			priority: 127, // TODO,default to mid value, see: https://github.com/moq-wg/moq-transport/issues/504
 		})
 
 		let object = 0

--- a/lib/transport/objects.ts
+++ b/lib/transport/objects.ts
@@ -121,7 +121,7 @@ export class Objects {
 				type,
 				sub: await r.u62(),
 				track: await r.u62(),
-				priority: await r.u8(),
+				publisher_priority: await r.u8(),
 			}
 
 			res = new TrackReader(h, r)
@@ -131,7 +131,7 @@ export class Objects {
 				sub: await r.u62(),
 				track: await r.u62(),
 				group: await r.u53(),
-				priority: await r.u8(),
+				publisher_priority: await r.u8(),
 			}
 			res = new GroupReader(h, r)
 		} else if (type == StreamType.Object) {
@@ -142,7 +142,7 @@ export class Objects {
 				group: await r.u53(),
 				object: await r.u53(),
 				status: await r.u53(),
-				priority: await r.u8(),
+				publisher_priority: await r.u8(),
 			}
 
 			res = new ObjectReader(h, r)

--- a/lib/transport/objects.ts
+++ b/lib/transport/objects.ts
@@ -18,7 +18,7 @@ export interface TrackHeader {
 	type: StreamType.Track
 	sub: bigint
 	track: bigint
-	priority: number // VarInt with a u32 maximum value
+	publisher_priority: number // VarInt with a u32 maximum value
 }
 
 export interface TrackChunk {
@@ -32,7 +32,7 @@ export interface GroupHeader {
 	sub: bigint
 	track: bigint
 	group: number // The group sequence, as a number because 2^53 is enough.
-	priority: number // VarInt with a u32 maximum value
+	publisher_priority: number // VarInt with a u32 maximum value
 }
 
 export interface GroupChunk {
@@ -46,7 +46,7 @@ export interface ObjectHeader {
 	track: bigint
 	group: number
 	object: number
-	priority: number
+	publisher_priority: number
 	status: number
 }
 
@@ -82,17 +82,17 @@ export class Objects {
 		if (h.type == StreamType.Object) {
 			await w.u53(h.group)
 			await w.u53(h.object)
-			await w.u8(h.priority)
+			await w.u8(h.publisher_priority)
 			await w.u53(h.status)
 
 			res = new ObjectWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Group) {
 			await w.u53(h.group)
-			await w.u8(h.priority)
+			await w.u8(h.publisher_priority)
 
 			res = new GroupWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Track) {
-			await w.u8(h.priority)
+			await w.u8(h.publisher_priority)
 
 			res = new TrackWriter(h, w) as WriterType<T>
 		} else {

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -214,7 +214,7 @@ export class SubscribeRecv {
 			type: StreamType.Track,
 			sub: this.#id,
 			track: this.#trackId,
-			priority: props?.priority ?? 0,
+			publisher_priority: props?.priority ?? 127,
 		})
 	}
 
@@ -225,7 +225,7 @@ export class SubscribeRecv {
 			sub: this.#id,
 			track: this.#trackId,
 			group: props.group,
-			priority: props.priority ?? 0,
+			publisher_priority: props.priority ?? 127,
 		})
 	}
 
@@ -237,7 +237,7 @@ export class SubscribeRecv {
 			track: this.#trackId,
 			group: props.group,
 			object: props.object,
-			priority: props.priority ?? 0,
+			publisher_priority: props.priority ?? 127,
 			status: 0,
 		})
 	}


### PR DESCRIPTION
The PR holds the code changes for interop support of "/publish" in moq-js with draft-05 version [moq-rs](https://github.com/TilsonJoji/englishm-moq-rs).

At times crash was observed during decoding u8 while testing interop with draft-05 Publish endpoint of moq-js , This [PR](https://github.com/TilsonJoji/englishm-moq-rs/pull/4) in moq-rs attempts to defend it.