### PR TITLE
Support display of available video tracks as drop-down and to swap among them

### DIFF
--- a/lib/transport/connection.ts
+++ b/lib/transport/connection.ts
@@ -55,6 +55,10 @@ export class Connection {
 		return this.#subscriber.subscribe(namespace, track)
 	}
 
+	unsubscribe(track: string) {
+		return this.#subscriber.unsubscribe(track)
+	}
+
 	subscribed() {
 		return this.#publisher.subscribed()
 	}

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -18,6 +18,8 @@ export class Subscriber {
 	#subscribe = new Map<bigint, SubscribeSend>()
 	#subscribeNext = 0n
 
+	#trackToIDMap = new Map<string, bigint>()
+
 	constructor(control: Control.Stream, objects: Objects) {
 		this.#control = control
 		this.#objects = objects
@@ -66,6 +68,8 @@ export class Subscriber {
 		const subscribe = new SubscribeSend(this.#control, id, namespace, track)
 		this.#subscribe.set(id, subscribe)
 
+		this.#trackToIDMap.set(track, id)
+
 		await this.#control.send({
 			kind: Control.Msg.Subscribe,
 			id,
@@ -80,6 +84,24 @@ export class Subscriber {
 		})
 
 		return subscribe
+	}
+
+	async unsubscribe(track: string) {
+		if (this.#trackToIDMap.has(track)) {
+			const trackID = this.#trackToIDMap.get(track)
+			if (trackID === undefined) {
+				console.warn(`Exception track ${track} not found in trackToIDMap.`)
+				return
+			}
+			try {
+				await this.#control.send({ kind: Control.Msg.Unsubscribe, id: trackID })
+				this.#trackToIDMap.delete(track)
+			} catch (error) {
+				console.error(`Failed to unsubscribe from track ${track}:`, error)
+			}
+		} else {
+			console.warn(`During unsubscribe request initiation attempt track ${track} not found in trackToIDMap.`)
+		}
 	}
 
 	recvSubscribeOk(msg: Control.SubscribeOk) {


### PR DESCRIPTION
The PR hosts the code changes to support the following:


- [ ]  Display available video tracks as a drop-down under the video , track names will be displayed in the drop-down.

- With this [PR](https://github.com/TilsonJoji/englishm-moq-rs/pull/5) , dev/pub script when "multi" is passed as an argument, 3 video tracks and an audio track will be ingested via moq-pub and on subscribing to the namespace , user will be able to see 3 video tracks as a drop-down

- [ ]  User can swap between video tracks by clicking on the track name in the dropdown , the video track will be changed without page refresh.

- [ ]  Subscribe to a particular track by appending the track in the URL or selecting a track from the dropdown list.


- The current way to subscribe to a namespace , this would default subscribe to the first video track along with audio track

          
                   https://SERVERIP:4321/watch/bbb?server=SERVERIP:4443
          

- To subscribe to a specfic track , append the track number at the end of the URL as below:

          
                   https://SERVERIP:4321/watch/bbb?server=SERVERIP:4443&track=1 [ Track number starts from 0 ] 

- [ ]  Tracks selected would be retained on page-reload.

- [ ]  Send unsubscribe request for a particular track to moq-relay.



- When a new track is selected from the drop down , unsubscribe is sent to moq-relay for the current track and subscribe is sent to the selected track.
- As of now relay responds with a code 1(SUBSRIBE_ERROR) , cancelled to an unsubscribe request from moq-js.

          
              
            

- [ ] need to explore moq-rs on the same , to send the appropriate response on receiving unsubscribe from moq-js

- [ ]  During UT an error was encountered wherein VideoDecoder expects a key frame immediately after a configure() or flush() for a avc , changes were done to wait for keyframe after a configure , before the first call to decode.
        
              

- [ ] Due to this initial wait for key frame , at times it takes few seconds for the video playback to start.
- [ ]               Need to explore if there are any alternate way to make VideoDecoder not demand a key frame immediately after a configure() or flush()